### PR TITLE
fix a misleading mistake in the settings

### DIFF
--- a/nvim/lua/core/options.lua
+++ b/nvim/lua/core/options.lua
@@ -78,6 +78,6 @@ local disabled_built_ins = {
 }
 
 for _, plugin in pairs(disabled_built_ins) do
-  g["loaded_" .. plugin] = 1
+  g["loaded_" .. plugin] = 0
 end
 


### PR DESCRIPTION
The comment and the code suggest it's disabled. `0` is disabled.