### PR TITLE
Define color scheme in a single file

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ See: [nvim-lspconfig #doc/server_configurations.md](https://github.com/neovim/nv
 
 **Icons:** [nvim-web-devicons](https://github.com/kyazdani42/nvim-web-devicons)
 
-The color scheme (default: OneDark) is defined in the following files:
+The color scheme (default: OneDark) is defined in the following file:
 
 * Neovim UI - [nvim/lua/core/colors.lua](nvim/lua/core/colors.lua):
 
@@ -190,13 +190,9 @@ require('onedark').setup {
     style = 'darker'
 }
 require('onedark').load()
-```
 
-* Statusline - [nvim/lua/core/statusline.lua](nvim/lua/core/statusline.lua):
-
-```lua
--- Set colorscheme (from core/colors.lua/colorscheme_name)
-local colors = require('core/colors').onedark_dark
+-- Return colorscheme for statusline:
+return M.onedark_dark
 ```
 
 ## Keymaps

--- a/nvim/lua/core/colors.lua
+++ b/nvim/lua/core/colors.lua
@@ -25,12 +25,12 @@ require('onedark').load()
 
 --[[
 Statusline color schemes.
-Import the following color schemes in your statusline.lua file
-with: `require('core/colors').colorscheme_name` where the colors scheme name
+Return the selected color scheme in this file with:
+`return M.colorscheme_name` where the color scheme name
 is the value of the variables below.
 
-e.g.: `local colors = require('core/colors').onedark_dark
-See: `core/statusline.lua`
+e.g.: `return M.onedark_dark`
+The returned value will be used by `core/statusline.lua`
 
 The color schemes below are created by following the "palette" file color
 schemes. Color names are adapted to maintain a pattern, original names can be
@@ -78,4 +78,4 @@ M.rose_pine = {
   red = '#ebbcba',
 }
 
-return M
+return M.onedark_dark

--- a/nvim/lua/core/statusline.lua
+++ b/nvim/lua/core/statusline.lua
@@ -16,8 +16,8 @@ if not status_ok then
   return
 end
 
--- Set colorscheme (from core/colors.lua/colorscheme_name)
-local colors = require('core/colors').onedark_dark
+-- Set colorscheme (from core/colors.lua)
+local colors = require('core/colors')
 
 local vi_mode_colors = {
   NORMAL = colors.cyan,


### PR DESCRIPTION
Maybe it is more *KISS* to configure color scheme in `core/colors.lua`, while `core/statusline.lua` require a colors table following the "palette" file color scheme.